### PR TITLE
Add Node.js gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Dependencies
+node_modules/
+
+# Build outputs
+dist/
+coverage/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+*.log
+
+# Environment variables
+.env
+.env.local
+.env.*.local
+
+# Misc
+.DS_Store
+


### PR DESCRIPTION
## Summary
- ignore node_modules, build outputs, logs, and environment files

## Testing
- `npm test` *(fails: Cannot find module '/workspace/aem-mcp-server/dist/tests/run-tests.js')*


------
https://chatgpt.com/codex/tasks/task_e_68c3c26d0e5c832e86c686af054ce336