### PR TITLE
feat(logger): add file size-based log rotation

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, appendFileSync, existsSync, mkdirSync } from 'fs';
+import { appendFileSync, existsSync, mkdirSync, statSync, renameSync, unlinkSync } from 'fs';
 import { join } from 'path';
 
 export enum LogLevel {
@@ -106,19 +106,54 @@ export class Logger {
     }
   }
 
+  private checkRotation(filePath: string, nextEntry: string): void {
+    if (!existsSync(filePath)) return;
+
+    try {
+      const stats = statSync(filePath);
+      if (stats.size + Buffer.byteLength(nextEntry, 'utf8') > this.config.maxFileSize) {
+        this.rotateLogs(filePath);
+      }
+    } catch (error) {
+      console.error('Failed to check log file size:', error);
+    }
+  }
+
+  private rotateLogs(filePath: string): void {
+    const max = this.config.maxFiles;
+    const oldest = `${filePath}.${max}`;
+    if (existsSync(oldest)) {
+      unlinkSync(oldest);
+    }
+
+    for (let i = max - 1; i >= 1; i--) {
+      const src = `${filePath}.${i}`;
+      const dest = `${filePath}.${i + 1}`;
+      if (existsSync(src)) {
+        renameSync(src, dest);
+      }
+    }
+
+    if (existsSync(filePath)) {
+      renameSync(filePath, `${filePath}.1`);
+    }
+  }
+
   private writeToFile(entry: LogEntry): void {
     if (!this.config.enableFile) return;
 
     try {
       const message = this.formatMessage(entry) + '\n';
+
+      // Check if rotation needed for main log file before writing
+      this.checkRotation(this.logFilePath, message);
       appendFileSync(this.logFilePath, message, 'utf8');
-      
+
       // Also write errors to separate error log
       if (entry.level === LogLevel.ERROR) {
+        this.checkRotation(this.errorFilePath, message);
         appendFileSync(this.errorFilePath, message, 'utf8');
       }
-      
-      // TODO: Implement log rotation based on file size
     } catch (error) {
       console.error('Failed to write to log file:', error);
     }

--- a/tests/logger.test.mjs
+++ b/tests/logger.test.mjs
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, existsSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { Logger } from '../dist/logger.js';
+
+const bigMessage = 'x'.repeat(200);
+
+function logFileBase(dir, type = 'aem-mcp') {
+  const date = new Date().toISOString().split('T')[0];
+  return join(dir, `${type}-${date}.log`);
+}
+
+test('rotates log files when maxFileSize exceeded', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'logger-test-'));
+  const logger = new Logger({
+    enableConsole: false,
+    logDirectory: dir,
+    maxFileSize: 100,
+    maxFiles: 2,
+    enableStructuredLogging: false,
+  });
+
+  logger.info(bigMessage);
+  logger.info(bigMessage);
+  logger.info(bigMessage);
+  logger.info(bigMessage);
+
+  const base = logFileBase(dir);
+  assert.ok(existsSync(base));
+  assert.ok(existsSync(`${base}.1`));
+  assert.ok(existsSync(`${base}.2`));
+  assert.ok(!existsSync(`${base}.3`));
+
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('rotates error logs separately when maxFileSize exceeded', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'logger-error-test-'));
+  const logger = new Logger({
+    enableConsole: false,
+    logDirectory: dir,
+    maxFileSize: 100,
+    maxFiles: 1,
+    enableStructuredLogging: false,
+  });
+
+  logger.error(bigMessage);
+  logger.error(bigMessage);
+
+  const base = logFileBase(dir, 'aem-mcp-errors');
+  assert.ok(existsSync(base));
+  assert.ok(existsSync(`${base}.1`));
+  assert.ok(!existsSync(`${base}.2`));
+
+  rmSync(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- rotate log and error files when exceeding `maxFileSize`
- limit number of backup files to `maxFiles`
- add tests covering rotation for standard and error logs

## Testing
- `node --test tests/logger.test.mjs`
- `npm test` *(fails: Cannot find module '/workspace/aem-mcp-server/dist/tests/run-tests.js')*

------
https://chatgpt.com/codex/tasks/task_e_68c3d00944b8832e8f0b00165812ce52