### PR TITLE
refactor: modularize AEM operations

### DIFF
--- a/src/aem-connector.ts
+++ b/src/aem-connector.ts
@@ -34,6 +34,7 @@ export class AEMConnector {
   config: AEMConnectorConfig;
   auth: { username: string; password: string };
   aemConfig: AEMConfig;
+  client: AxiosInstance;
 
   constructor() {
     this.config = this.loadConfig();
@@ -46,6 +47,16 @@ export class AEMConnector {
       this.config.aem.host = process.env.AEM_HOST;
       this.config.aem.author = process.env.AEM_HOST;
     }
+
+    this.client = axios.create({
+      baseURL: this.config.aem.host,
+      auth: this.auth,
+      timeout: 30000,
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+      },
+    });
   }
 
   loadConfig(): AEMConnectorConfig {
@@ -74,15 +85,7 @@ export class AEMConnector {
   }
 
   createAxiosInstance(): AxiosInstance {
-    return axios.create({
-      baseURL: this.config.aem.host,
-      auth: this.auth,
-      timeout: 30000,
-      headers: {
-        'Content-Type': 'application/json',
-        'Accept': 'application/json',
-      },
-    });
+    return this.client;
   }
 
   async testConnection(): Promise<boolean> {

--- a/src/aem/assets.ts
+++ b/src/aem/assets.ts
@@ -1,0 +1,6 @@
+import { aemClient } from './client.js';
+
+export const getAssetMetadata = (assetPath: string) => aemClient.getAssetMetadata(assetPath);
+export const uploadAsset = (params: any) => aemClient.uploadAsset(params);
+export const updateAsset = (params: any) => aemClient.updateAsset(params);
+export const deleteAsset = (params: any) => aemClient.deleteAsset(params);

--- a/src/aem/client.ts
+++ b/src/aem/client.ts
@@ -1,0 +1,3 @@
+import { AEMConnector } from '../aem-connector.js';
+
+export const aemClient = new AEMConnector();

--- a/src/aem/components.ts
+++ b/src/aem/components.ts
@@ -1,0 +1,10 @@
+import { aemClient } from './client.js';
+
+export const validateComponent = (params: any) => aemClient.validateComponent(params);
+export const updateComponent = (params: any) => aemClient.updateComponent(params);
+export const undoChanges = (params: any) => aemClient.undoChanges(params);
+export const scanPageComponents = (pagePath: string) => aemClient.scanPageComponents(pagePath);
+export const updateImagePath = (componentPath: string, newImagePath: string) => aemClient.updateImagePath(componentPath, newImagePath);
+export const createComponent = (params: any) => aemClient.createComponent(params);
+export const deleteComponent = (params: any) => aemClient.deleteComponent(params);
+export const bulkUpdateComponents = (params: any) => aemClient.bulkUpdateComponents(params);

--- a/src/aem/pages.ts
+++ b/src/aem/pages.ts
@@ -1,0 +1,23 @@
+import { aemClient } from './client.js';
+
+export const fetchSites = () => aemClient.fetchSites();
+export const fetchLanguageMasters = (site: string) => aemClient.fetchLanguageMasters(site);
+export const fetchAvailableLocales = (site: string, languageMasterPath: string) => aemClient.fetchAvailableLocales(site, languageMasterPath);
+export const replicateAndPublish = (selectedLocales: any, componentData: any, localizedOverrides: any) => aemClient.replicateAndPublish(selectedLocales, componentData, localizedOverrides);
+export const getAllTextContent = (pagePath: string) => aemClient.getAllTextContent(pagePath);
+export const getPageTextContent = (pagePath: string) => aemClient.getPageTextContent(pagePath);
+export const getPageImages = (pagePath: string) => aemClient.getPageImages(pagePath);
+export const getPageContent = (pagePath: string) => aemClient.getPageContent(pagePath);
+export const listPages = (siteRoot: string, depth?: number, limit?: number) => aemClient.listPages(siteRoot, depth, limit);
+export const getNodeContent = (path: string, depth?: number) => aemClient.getNodeContent(path, depth);
+export const listChildren = (path: string) => aemClient.listChildren(path);
+export const getPageProperties = (pagePath: string) => aemClient.getPageProperties(pagePath);
+export const searchContent = (params: any) => aemClient.searchContent(params);
+export const executeJCRQuery = (query: string, limit?: number) => aemClient.executeJCRQuery(query, limit);
+export const createPage = (params: any) => aemClient.createPage(params);
+export const deletePage = (params: any) => aemClient.deletePage(params);
+export const unpublishContent = (params: any) => aemClient.unpublishContent(params);
+export const activatePage = (params: any) => aemClient.activatePage(params);
+export const deactivatePage = (params: any) => aemClient.deactivatePage(params);
+export const getTemplates = (sitePath: string) => aemClient.getTemplates(sitePath);
+export const getTemplateStructure = (templatePath: string) => aemClient.getTemplateStructure(templatePath);

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -3,8 +3,8 @@ import cors from 'cors';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import dotenv from 'dotenv';
-import { AEMConnector } from './aem-connector.js';
 import { MCPRequestHandler } from './mcp-handler.js';
+import { aemClient } from './aem/client.js';
 import { logger, loggingMiddleware, generateRequestId } from './logger.js';
 import swaggerUi from 'swagger-ui-express';
 import swaggerJSDoc from 'swagger-jsdoc';
@@ -46,8 +46,7 @@ if (process.env.MCP_USERNAME && process.env.MCP_PASSWORD) {
   app.use('/mcp', basicAuth);
 }
 
-const aemConnector = new AEMConnector();
-const mcpHandler = new MCPRequestHandler(aemConnector);
+const mcpHandler = new MCPRequestHandler();
 
 // Method validation middleware
 const validateMethod = (req: Request, res: Response, next: NextFunction) => {
@@ -121,7 +120,7 @@ const handleError = (error: any, req: Request, res: Response, next: NextFunction
 // Enhanced health check endpoint
 app.get('/health', async (req, res) => {
   try {
-    const aemConnected = await aemConnector.testConnection();
+    const aemConnected = await aemClient.testConnection();
     const healthData = {
       status: aemConnected ? 'healthy' : 'degraded',
       aem: {
@@ -159,7 +158,7 @@ app.get('/health', async (req, res) => {
 // Detailed health check endpoint
 app.get('/health/detailed', async (req, res) => {
   try {
-    const aemConnected = await aemConnector.testConnection();
+    const aemConnected = await aemClient.testConnection();
     const methods = mcpHandler.getAvailableMethods();
     
     const detailedHealth = {

--- a/src/mcp-handler.ts
+++ b/src/mcp-handler.ts
@@ -1,92 +1,90 @@
-import { AEMConnector } from './aem-connector.js';
+import * as components from './aem/components.js';
+import * as pages from './aem/pages.js';
+import * as assets from './aem/assets.js';
 
 export class MCPRequestHandler {
-  aemConnector: AEMConnector;
-
-  constructor(aemConnector: AEMConnector) {
-    this.aemConnector = aemConnector;
-  }
+  constructor() {}
 
   async handleRequest(method: string, params: any) {
     try {
       switch (method) {
         case 'validateComponent':
-          return await this.aemConnector.validateComponent(params);
+          return await components.validateComponent(params);
         case 'updateComponent':
-          return await this.aemConnector.updateComponent(params);
+          return await components.updateComponent(params);
         case 'undoChanges':
-          return await this.aemConnector.undoChanges(params);
+          return await components.undoChanges(params);
         case 'scanPageComponents':
-          return await this.aemConnector.scanPageComponents(params.pagePath);
+          return await components.scanPageComponents(params.pagePath);
         case 'fetchSites':
-          return await this.aemConnector.fetchSites();
+          return await pages.fetchSites();
         case 'fetchLanguageMasters':
-          return await this.aemConnector.fetchLanguageMasters(params.site);
+          return await pages.fetchLanguageMasters(params.site);
         case 'fetchAvailableLocales':
-          return await this.aemConnector.fetchAvailableLocales(params.site, params.languageMasterPath);
+          return await pages.fetchAvailableLocales(params.site, params.languageMasterPath);
         case 'replicateAndPublish':
-          return await this.aemConnector.replicateAndPublish(params.selectedLocales, params.componentData, params.localizedOverrides);
+          return await pages.replicateAndPublish(params.selectedLocales, params.componentData, params.localizedOverrides);
         case 'getAllTextContent':
-          return await this.aemConnector.getAllTextContent(params.pagePath);
+          return await pages.getAllTextContent(params.pagePath);
         case 'getPageTextContent':
-          return await this.aemConnector.getPageTextContent(params.pagePath);
+          return await pages.getPageTextContent(params.pagePath);
         case 'getPageImages':
-          return await this.aemConnector.getPageImages(params.pagePath);
+          return await pages.getPageImages(params.pagePath);
         case 'updateImagePath':
-          return await this.aemConnector.updateImagePath(params.componentPath, params.newImagePath);
+          return await components.updateImagePath(params.componentPath, params.newImagePath);
         case 'getPageContent':
-          return await this.aemConnector.getPageContent(params.pagePath);
+          return await pages.getPageContent(params.pagePath);
         case 'listPages':
-          return await this.aemConnector.listPages(params.siteRoot || params.path || '/content', params.depth || 1, params.limit || 20);
+          return await pages.listPages(params.siteRoot || params.path || '/content', params.depth || 1, params.limit || 20);
         case 'getNodeContent':
-          return await this.aemConnector.getNodeContent(params.path, params.depth || 1);
+          return await pages.getNodeContent(params.path, params.depth || 1);
         case 'listChildren':
-          return await this.aemConnector.listChildren(params.path);
+          return await pages.listChildren(params.path);
         case 'getPageProperties':
-          return await this.aemConnector.getPageProperties(params.pagePath);
+          return await pages.getPageProperties(params.pagePath);
         case 'searchContent':
-          return await this.aemConnector.searchContent(params);
+          return await pages.searchContent(params);
         case 'executeJCRQuery':
-          return await this.aemConnector.executeJCRQuery(params.query, params.limit);
+          return await pages.executeJCRQuery(params.query, params.limit);
         case 'getAssetMetadata':
-          return await this.aemConnector.getAssetMetadata(params.assetPath);
+          return await assets.getAssetMetadata(params.assetPath);
         case 'getStatus':
           return this.getWorkflowStatus(params.workflowId);
         case 'listMethods':
           return { methods: this.getAvailableMethods() };
         case 'enhancedPageSearch':
-          return await this.aemConnector.searchContent({
+          return await pages.searchContent({
             fulltext: params.searchTerm,
             path: params.basePath,
             type: 'cq:Page',
             limit: 20
           });
         case 'createPage':
-          return await this.aemConnector.createPage(params);
+          return await pages.createPage(params);
         case 'deletePage':
-          return await this.aemConnector.deletePage(params);
+          return await pages.deletePage(params);
         case 'createComponent':
-          return await this.aemConnector.createComponent(params);
+          return await components.createComponent(params);
         case 'deleteComponent':
-          return await this.aemConnector.deleteComponent(params);
+          return await components.deleteComponent(params);
         case 'unpublishContent':
-          return await this.aemConnector.unpublishContent(params);
+          return await pages.unpublishContent(params);
         case 'activatePage':
-          return await this.aemConnector.activatePage(params);
+          return await pages.activatePage(params);
         case 'deactivatePage':
-          return await this.aemConnector.deactivatePage(params);
+          return await pages.deactivatePage(params);
         case 'uploadAsset':
-          return await this.aemConnector.uploadAsset(params);
+          return await assets.uploadAsset(params);
         case 'updateAsset':
-          return await this.aemConnector.updateAsset(params);
+          return await assets.updateAsset(params);
         case 'deleteAsset':
-          return await this.aemConnector.deleteAsset(params);
+          return await assets.deleteAsset(params);
         case 'getTemplates':
-          return await this.aemConnector.getTemplates(params.sitePath);
+          return await pages.getTemplates(params.sitePath);
         case 'getTemplateStructure':
-          return await this.aemConnector.getTemplateStructure(params.templatePath);
+          return await pages.getTemplateStructure(params.templatePath);
         case 'bulkUpdateComponents':
-          return await this.aemConnector.bulkUpdateComponents(params);
+          return await components.bulkUpdateComponents(params);
         default:
           throw new Error(`Unknown method: ${method}`);
       }


### PR DESCRIPTION
## Summary
- split AEM-related functionality into components, pages, and assets modules
- reuse a single Axios client across AEM calls
- update MCP request handler and gateway to use new modules

## Testing
- `npm test` *(fails: Cannot find module '/workspace/aem-mcp-server/dist/tests/run-tests.js')*


------
https://chatgpt.com/codex/tasks/task_e_68c3d16133fc832e9ee39c3547f3b6b4