### PR TITLE
Centralize MCP method categorization

### DIFF
--- a/src/mcp-handler.ts
+++ b/src/mcp-handler.ts
@@ -1,6 +1,7 @@
 import * as components from './aem/components.js';
 import * as pages from './aem/pages.js';
 import * as assets from './aem/assets.js';
+import { categorizeMethod } from './utils/method-categorizer.js';
 
 export class MCPRequestHandler {
   constructor() {}
@@ -104,7 +105,7 @@ export class MCPRequestHandler {
   }
 
   getAvailableMethods() {
-    return [
+    const methods = [
       { name: 'validateComponent', description: 'Validate component changes before applying them', parameters: ['locale', 'page_path', 'component', 'props'] },
       { name: 'updateComponent', description: 'Update component properties in AEM', parameters: ['componentPath', 'properties'] },
       { name: 'undoChanges', description: 'Undo the last component changes', parameters: ['job_id'] },
@@ -142,5 +143,7 @@ export class MCPRequestHandler {
       { name: 'getTemplateStructure', description: 'Get detailed structure of a specific template', parameters: ['templatePath'] },
       { name: 'bulkUpdateComponents', description: 'Update multiple components in a single operation with validation and rollback support', parameters: ['updates', 'validateFirst', 'continueOnError'] },
     ];
+
+    return methods.map(m => ({ ...m, category: categorizeMethod(m.name) }));
   }
 } 

--- a/src/utils/method-categorizer.ts
+++ b/src/utils/method-categorizer.ts
@@ -1,0 +1,20 @@
+export function categorizeMethod(name: string): string {
+  if (name.includes('Page')) return 'page';
+  if (name.includes('Component')) return 'component';
+  if (name.includes('Asset')) return 'asset';
+  if (name.includes('Template')) return 'template';
+  if (/search/i.test(name)) return 'search';
+  if (name.includes('Site') || name.includes('Language') || name.includes('Locale')) return 'site';
+  if (name.includes('publish') || name.includes('activate') || name.includes('replicate')) return 'replication';
+  if (name.includes('Node') || name.includes('Children')) return 'legacy';
+  return 'utility';
+}
+
+export function categorizeMethods(methods: any[]): Record<string, any[]> {
+  return methods.reduce((acc: Record<string, any[]>, method: any) => {
+    const category = method.category || categorizeMethod(method.name);
+    if (!acc[category]) acc[category] = [];
+    acc[category].push(method);
+    return acc;
+  }, {} as Record<string, any[]>);
+}


### PR DESCRIPTION
## Summary
- add `categorizeMethod` and `categorizeMethods` utilities
- have `getAvailableMethods` include category metadata
- reuse category helper in health and API method routes

## Testing
- `npm test` *(fails: Cannot find module '/workspace/aem-mcp-server/dist/tests/run-tests.js')*

------
https://chatgpt.com/codex/tasks/task_e_68c3d59adcdc832ebaf09934828f0868