### PR TITLE
feat: use keep-alive agents

### DIFF
--- a/src/aem-connector.ts
+++ b/src/aem-connector.ts
@@ -1,4 +1,6 @@
 import axios, { AxiosInstance } from 'axios';
+import http from 'http';
+import https from 'https';
 import dotenv from 'dotenv';
 import { getAEMConfig, isValidContentPath, isValidComponentType, isValidLocale, AEMConfig } from './aem-config.js';
 import {
@@ -48,6 +50,16 @@ export class AEMConnector {
       this.config.aem.author = process.env.AEM_HOST;
     }
 
+    const maxSockets = process.env.AEM_MAX_SOCKETS
+      ? parseInt(process.env.AEM_MAX_SOCKETS, 10)
+      : undefined;
+    const agentOptions: http.AgentOptions = { keepAlive: true };
+    if (maxSockets && !isNaN(maxSockets)) {
+      agentOptions.maxSockets = maxSockets;
+    }
+    const httpAgent = new http.Agent(agentOptions);
+    const httpsAgent = new https.Agent(agentOptions);
+
     this.client = axios.create({
       baseURL: this.config.aem.host,
       auth: this.auth,
@@ -56,6 +68,8 @@ export class AEMConnector {
         'Content-Type': 'application/json',
         'Accept': 'application/json',
       },
+      httpAgent,
+      httpsAgent,
     });
   }
 


### PR DESCRIPTION
## Summary
- use keep-alive HTTP/HTTPS agents for axios
- allow tuning agent max sockets via `AEM_MAX_SOCKETS`

## Testing
- `npm test` *(fails: Cannot find module '/workspace/aem-mcp-server/dist/tests/run-tests.js')*


------
https://chatgpt.com/codex/tasks/task_e_68c3e9fcbb24832ebd6293d94215487a