### PR TITLE
Clamp search query limits and validate path

### DIFF
--- a/src/aem-connector.ts
+++ b/src/aem-connector.ts
@@ -679,9 +679,34 @@ export class AEMConnector {
   async searchContent(params: any): Promise<object> {
     return safeExecute<object>(async () => {
       const client = this.createAxiosInstance();
-      const response = await client.get(this.config.aem.endpoints.query, { params });
+      const queryParams: any = { ...params };
+
+      const maxLimit = this.aemConfig.queries.maxLimit;
+      const defaultLimit = this.aemConfig.queries.defaultLimit;
+
+      let limit = queryParams.limit ?? queryParams['p.limit'];
+      if (limit === undefined || limit === null) {
+        limit = defaultLimit;
+      }
+      let limitNum = parseInt(limit as string, 10);
+      if (isNaN(limitNum) || limitNum <= 0) {
+        limitNum = defaultLimit;
+      }
+      limitNum = Math.min(limitNum, maxLimit);
+      if ('p.limit' in queryParams || !('limit' in queryParams)) {
+        queryParams['p.limit'] = limitNum.toString();
+        delete queryParams.limit;
+      } else {
+        queryParams.limit = limitNum;
+      }
+
+      if (queryParams.path && !isValidContentPath(queryParams.path, this.aemConfig)) {
+        queryParams.path = this.aemConfig.contentPaths.sitesRoot;
+      }
+
+      const response = await client.get(this.config.aem.endpoints.query, { params: queryParams });
       return createSuccessResponse({
-        params,
+        params: queryParams,
         results: response.data.hits || [],
         total: response.data.total || 0,
         rawResponse: response.data,


### PR DESCRIPTION
## Summary
- Enforce query limit bounds and defaults in `searchContent`
- Validate optional search path against allowed content roots

## Testing
- `npm test` *(fails: Cannot find module '/workspace/aem-mcp-server/dist/tests/run-tests.js')*

------
https://chatgpt.com/codex/tasks/task_e_68c3e9e79e40832e83245cde0841cfed