### PR TITLE
feat: add asset activation methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Reach out to me on [LinkedIn](https://www.linkedin.com/in/indrasish/) or [Email 
 [![TypeScript](https://img.shields.io/badge/typescript-5.8%2B-blue.svg)](https://www.typescriptlang.org/)
 [![MCP Protocol](https://img.shields.io/badge/MCP-1.15.0-green.svg)](https://modelcontextprotocol.io/)
 
-AEM MCP Server is a comprehensive, production-ready Model Context Protocol (MCP) server for Adobe Experience Manager (AEM). It provides 35+ robust REST/JSON-RPC API methods for complete content, component, asset, and template management, with advanced integrations for AI, chatbots, and automation workflows. This project is designed for AEM developers, content teams, and automation engineers who want to manage AEM programmatically or via natural language interfaces.
+AEM MCP Server is a comprehensive, production-ready Model Context Protocol (MCP) server for Adobe Experience Manager (AEM). It provides 37+ robust REST/JSON-RPC API methods for complete content, component, asset, and template management, with advanced integrations for AI, chatbots, and automation workflows. This project is designed for AEM developers, content teams, and automation engineers who want to manage AEM programmatically or via natural language interfaces.
 
 ---
 
@@ -43,7 +43,7 @@ AEM MCP Server is a comprehensive, production-ready Model Context Protocol (MCP)
 
 ## Features
 
-### 🚀 Core Capabilities (35+ Methods)
+### 🚀 Core Capabilities (37+ Methods)
 
 #### Page Operations (10 methods)
 - **Page Lifecycle**: Create, delete, activate/deactivate pages with proper template integration
@@ -57,10 +57,11 @@ AEM MCP Server is a comprehensive, production-ready Model Context Protocol (MCP)
 - **Component Discovery**: Scan pages to discover all components and their properties
 - **Image Management**: Update image paths with verification
 
-#### Asset Operations (4 methods)
+#### Asset Operations (6 methods)
 - **DAM Management**: Upload, update, delete assets in AEM DAM
 - **Metadata Operations**: Get and update asset metadata
 - **File Processing**: Support for multiple file types with MIME type detection
+- **Publishing**: Activate or deactivate assets for the publish environment
 
 #### Search & Query Operations (3 methods)
 - **Advanced Search**: QueryBuilder integration with fulltext search
@@ -269,6 +270,8 @@ curl -u admin:admin \
 - `updateAsset` - Update asset metadata and content
 - `deleteAsset` - Remove assets from DAM
 - `getAssetMetadata` - Retrieve asset metadata
+- `activateAsset` - Publish assets to the publish environment
+- `deactivateAsset` - Unpublish assets from the publish environment
 
 #### Search Operations
 - `searchContent` - Query Builder search with flexible parameters

--- a/docs/method-inventory.json
+++ b/docs/method-inventory.json
@@ -1,6 +1,6 @@
 {
   "aemMcpMethods": {
-    "totalMethods": 35,
+    "totalMethods": 37,
     "categories": {
       "pageOperations": {
         "description": "Operations for managing AEM pages",
@@ -182,6 +182,22 @@
             "requiredParams": ["assetPath"],
             "returnType": "object",
             "category": "asset"
+          },
+          {
+            "name": "activateAsset",
+            "description": "Activate (publish) a DAM asset",
+            "parameters": ["assetPath", "activateTree"],
+            "requiredParams": ["assetPath"],
+            "returnType": "object",
+            "category": "asset"
+          },
+          {
+            "name": "deactivateAsset",
+            "description": "Deactivate (unpublish) a DAM asset",
+            "parameters": ["assetPath", "deactivateTree"],
+            "requiredParams": ["assetPath"],
+            "returnType": "object",
+            "category": "asset"
           }
         ]
       },
@@ -341,7 +357,7 @@
     "methodsByCategory": {
       "page": 10,
       "component": 7,
-      "asset": 4,
+      "asset": 6,
       "search": 3,
       "template": 2,
       "site": 3,

--- a/src/aem-connector.ts
+++ b/src/aem-connector.ts
@@ -1027,6 +1027,96 @@ export class AEMConnector {
     }, 'deactivatePage');
   }
 
+  async activateAsset(request: any): Promise<object> {
+    return safeExecute<object>(async () => {
+      const { assetPath, activateTree = false } = request;
+      if (!isValidContentPath(assetPath, this.aemConfig)) {
+        throw createAEMError(
+          AEM_ERROR_CODES.INVALID_PARAMETERS,
+          `Invalid asset path: ${String(assetPath)}`,
+          { assetPath }
+        );
+      }
+
+      const client = this.createAxiosInstance();
+
+      try {
+        const formData = new URLSearchParams();
+        formData.append('cmd', 'Activate');
+        formData.append('path', assetPath);
+        formData.append('ignoredeactivated', 'false');
+        formData.append('onlymodified', 'false');
+        if (activateTree) {
+          formData.append('deep', 'true');
+        }
+
+        const response = await client.post('/bin/replicate.json', formData, {
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+        });
+
+        return createSuccessResponse(
+          {
+            success: true,
+            activatedPath: assetPath,
+            activateTree,
+            response: response.data,
+            timestamp: new Date().toISOString(),
+          },
+          'activateAsset'
+        );
+      } catch (error: any) {
+        throw handleAEMHttpError(error, 'activateAsset');
+      }
+    }, 'activateAsset');
+  }
+
+  async deactivateAsset(request: any): Promise<object> {
+    return safeExecute<object>(async () => {
+      const { assetPath, deactivateTree = false } = request;
+      if (!isValidContentPath(assetPath, this.aemConfig)) {
+        throw createAEMError(
+          AEM_ERROR_CODES.INVALID_PARAMETERS,
+          `Invalid asset path: ${String(assetPath)}`,
+          { assetPath }
+        );
+      }
+
+      const client = this.createAxiosInstance();
+
+      try {
+        const formData = new URLSearchParams();
+        formData.append('cmd', 'Deactivate');
+        formData.append('path', assetPath);
+        formData.append('ignoredeactivated', 'false');
+        formData.append('onlymodified', 'false');
+        if (deactivateTree) {
+          formData.append('deep', 'true');
+        }
+
+        const response = await client.post('/bin/replicate.json', formData, {
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+        });
+
+        return createSuccessResponse(
+          {
+            success: true,
+            deactivatedPath: assetPath,
+            deactivateTree,
+            response: response.data,
+            timestamp: new Date().toISOString(),
+          },
+          'deactivateAsset'
+        );
+      } catch (error: any) {
+        throw handleAEMHttpError(error, 'deactivateAsset');
+      }
+    }, 'deactivateAsset');
+  }
+
   async uploadAsset(request: any): Promise<object> {
     return safeExecute<object>(async () => {
       const { parentPath, fileName, fileContent, mimeType, metadata = {} } = request;

--- a/src/aem/assets.ts
+++ b/src/aem/assets.ts
@@ -4,3 +4,5 @@ export const getAssetMetadata = (assetPath: string) => aemClient.getAssetMetadat
 export const uploadAsset = (params: any) => aemClient.uploadAsset(params);
 export const updateAsset = (params: any) => aemClient.updateAsset(params);
 export const deleteAsset = (params: any) => aemClient.deleteAsset(params);
+export const activateAsset = (params: any) => aemClient.activateAsset(params);
+export const deactivateAsset = (params: any) => aemClient.deactivateAsset(params);


### PR DESCRIPTION
## Summary
- add `activateAsset` and `deactivateAsset` leveraging `/bin/replicate.json`
- expose new asset activation helpers via public asset API
- document asset activation operations and update method inventory counts

## Testing
- `npm test` *(fails: Cannot find module 'dist/tests/run-tests.js')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c3eff3e1c0832e9c06bfbf66a96f95