### PR TITLE
Implement real AEM replication and update method docs

### DIFF
--- a/comprehensive-test.cjs
+++ b/comprehensive-test.cjs
@@ -79,7 +79,7 @@ class ComprehensiveTestRunner {
       {
         name: 'Replication Operations',
         tests: [
-          { name: 'replicateAndPublish', params: { selectedLocales: ['en'], componentData: { text: 'test' } } },
+          { name: 'replicateAndPublish', params: { contentPaths: ['/content/test'], publishTree: false } },
           { name: 'activatePage', params: { pagePath: '/content/test' } },
           { name: 'deactivatePage', params: { pagePath: '/content/test' } },
           { name: 'unpublishContent', params: { contentPaths: ['/content/test'] } },

--- a/dist/mcp-handler.js
+++ b/dist/mcp-handler.js
@@ -22,7 +22,7 @@ export class MCPRequestHandler {
                 case 'fetchAvailableLocales':
                     return await pages.fetchAvailableLocales(params.site, params.languageMasterPath);
                 case 'replicateAndPublish':
-                    return await pages.replicateAndPublish(params.selectedLocales, params.componentData, params.localizedOverrides);
+                    return await pages.replicateAndPublish(params);
                 case 'getAllTextContent':
                     return await pages.getAllTextContent(params.pagePath);
                 case 'getPageTextContent':
@@ -110,7 +110,7 @@ export class MCPRequestHandler {
             { name: 'fetchSites', description: 'Get all available sites in AEM', parameters: [] },
             { name: 'fetchLanguageMasters', description: 'Get language masters for a specific site', parameters: ['site'] },
             { name: 'fetchAvailableLocales', description: 'Get available locales for a site and language master', parameters: ['site', 'languageMasterPath'] },
-            { name: 'replicateAndPublish', description: 'Replicate and publish content to selected locales', parameters: ['selectedLocales', 'componentData', 'localizedOverrides'] },
+            { name: 'replicateAndPublish', description: 'Activate content paths using AEM replication', parameters: ['contentPaths', 'publishTree'] },
             { name: 'getAllTextContent', description: 'Get all text content from a page including titles, text components, and descriptions', parameters: ['pagePath'] },
             { name: 'getPageTextContent', description: 'Get text content from a specific page', parameters: ['pagePath'] },
             { name: 'getPageImages', description: 'Get all images from a page, including those within Experience Fragments', parameters: ['pagePath'] },

--- a/dist/mcp-server.js
+++ b/dist/mcp-server.js
@@ -92,15 +92,14 @@ const tools = [
     },
     {
         name: 'replicateAndPublish',
-        description: 'Replicate and publish content to selected locales',
+        description: 'Activate content paths using AEM replication',
         inputSchema: {
             type: 'object',
             properties: {
-                selectedLocales: { type: 'array', items: { type: 'string' } },
-                componentData: { type: 'object' },
-                localizedOverrides: { type: 'object' },
+                contentPaths: { type: 'array', items: { type: 'string' } },
+                publishTree: { type: 'boolean' },
             },
-            required: ['selectedLocales', 'componentData'],
+            required: ['contentPaths'],
         },
     },
     {
@@ -478,7 +477,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                 return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
             }
             case 'replicateAndPublish': {
-                const result = await aemConnector.replicateAndPublish(args.selectedLocales, args.componentData, args.localizedOverrides);
+                const result = await aemConnector.replicateAndPublish(args);
                 return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
             }
             case 'getAllTextContent': {

--- a/docs/method-inventory.json
+++ b/docs/method-inventory.json
@@ -269,9 +269,9 @@
         "methods": [
           {
             "name": "replicateAndPublish",
-            "description": "Replicate and publish content to selected locales",
-            "parameters": ["selectedLocales", "componentData", "localizedOverrides"],
-            "requiredParams": ["selectedLocales", "componentData"],
+            "description": "Activate content paths using AEM replication APIs",
+            "parameters": ["contentPaths", "publishTree"],
+            "requiredParams": ["contentPaths"],
             "returnType": "object",
             "category": "replication"
           },
@@ -353,7 +353,7 @@
       "createPageIssue": "Current implementation creates empty pages without proper jcr:content nodes, making them invisible in AEM Author mode",
       "undoChangesNotImplemented": "Method exists but not implemented - recommends using AEM version history",
       "getStatusMocked": "Returns mock 'completed' status for all workflow IDs",
-      "replicationSimulated": "Replication logic is currently simulated"
+      "replicateAndPublishUsesReplicationServlet": "replicateAndPublish uses /bin/replicate.json with WCM Command fallback"
     }
   }
 }

--- a/src/aem/pages.ts
+++ b/src/aem/pages.ts
@@ -3,7 +3,7 @@ import { aemClient } from './client.js';
 export const fetchSites = () => aemClient.fetchSites();
 export const fetchLanguageMasters = (site: string) => aemClient.fetchLanguageMasters(site);
 export const fetchAvailableLocales = (site: string, languageMasterPath: string) => aemClient.fetchAvailableLocales(site, languageMasterPath);
-export const replicateAndPublish = (selectedLocales: any, componentData: any, localizedOverrides: any) => aemClient.replicateAndPublish(selectedLocales, componentData, localizedOverrides);
+export const replicateAndPublish = (params: any) => aemClient.replicateAndPublish(params);
 export const getAllTextContent = (pagePath: string) => aemClient.getAllTextContent(pagePath);
 export const getPageTextContent = (pagePath: string) => aemClient.getPageTextContent(pagePath);
 export const getPageImages = (pagePath: string) => aemClient.getPageImages(pagePath);

--- a/src/mcp-handler.ts
+++ b/src/mcp-handler.ts
@@ -24,7 +24,7 @@ export class MCPRequestHandler {
         case 'fetchAvailableLocales':
           return await pages.fetchAvailableLocales(params.site, params.languageMasterPath);
         case 'replicateAndPublish':
-          return await pages.replicateAndPublish(params.selectedLocales, params.componentData, params.localizedOverrides);
+          return await pages.replicateAndPublish(params);
         case 'getAllTextContent':
           return await pages.getAllTextContent(params.pagePath);
         case 'getPageTextContent':
@@ -113,7 +113,7 @@ export class MCPRequestHandler {
       { name: 'fetchSites', description: 'Get all available sites in AEM', parameters: [] },
       { name: 'fetchLanguageMasters', description: 'Get language masters for a specific site', parameters: ['site'] },
       { name: 'fetchAvailableLocales', description: 'Get available locales for a site and language master', parameters: ['site', 'languageMasterPath'] },
-      { name: 'replicateAndPublish', description: 'Replicate and publish content to selected locales', parameters: ['selectedLocales', 'componentData', 'localizedOverrides'] },
+      { name: 'replicateAndPublish', description: 'Activate content paths using AEM replication', parameters: ['contentPaths', 'publishTree'] },
       { name: 'getAllTextContent', description: 'Get all text content from a page including titles, text components, and descriptions', parameters: ['pagePath'] },
       { name: 'getPageTextContent', description: 'Get text content from a specific page', parameters: ['pagePath'] },
       { name: 'getPageImages', description: 'Get all images from a page, including those within Experience Fragments', parameters: ['pagePath'] },

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -102,15 +102,14 @@ const tools: ToolDefinition[] = [
   },
   {
     name: 'replicateAndPublish',
-    description: 'Replicate and publish content to selected locales',
+    description: 'Activate content paths using AEM replication',
     inputSchema: {
       type: 'object',
       properties: {
-        selectedLocales: { type: 'array', items: { type: 'string' } },
-        componentData: { type: 'object' },
-        localizedOverrides: { type: 'object' },
+        contentPaths: { type: 'array', items: { type: 'string' } },
+        publishTree: { type: 'boolean' },
       },
-      required: ['selectedLocales', 'componentData'],
+      required: ['contentPaths'],
     },
   },
   {
@@ -490,7 +489,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request: any) => {
         return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
       }
       case 'replicateAndPublish': {
-        const result = await aemConnector.replicateAndPublish(args.selectedLocales, args.componentData, args.localizedOverrides);
+        const result = await aemConnector.replicateAndPublish(args);
         return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
       }
       case 'getAllTextContent': {

--- a/tests/test-cases.ts
+++ b/tests/test-cases.ts
@@ -381,14 +381,11 @@ export const replicationOperationsTests: TestCase[] = [
   {
     id: 'repl-001',
     methodName: 'replicateAndPublish',
-    description: 'Simulate replication and publish',
+    description: 'Replicate and publish test content',
     category: 'replication',
     parameters: {
-      selectedLocales: ['en_US'],
-      componentData: {
-        text: 'Test content for replication'
-      },
-      localizedOverrides: {}
+      contentPaths: ['/content/we-retail/us/en/mcp-test-page'],
+      publishTree: false
     }
   },
   {


### PR DESCRIPTION
## Summary
- replace simulated replicateAndPublish with real calls to `/bin/replicate.json` and fallback to `/bin/wcmcommand`
- add optional tree replication support and structured error handling
- document new parameters and behavior in method inventory

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find module 'dist/tests/run-tests.js')*

------
https://chatgpt.com/codex/tasks/task_e_68c3efee933c832e885e7075e11e7a99