### PR TITLE
docs: document workflow APIs and update deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,38 @@ curl -u admin:admin \
   }'
 ```
 
+#### 6. Start a workflow
+```bash
+curl -u admin:admin \
+  -X POST http://localhost:3001/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 6,
+    "method": "startWorkflow",
+    "params": {
+      "modelId": "/var/workflow/models/publish-page",
+      "payloadPath": "/content/mysite/en",
+      "title": "Publish Page"
+    }
+  }'
+```
+
+#### 7. Check workflow status
+```bash
+curl -u admin:admin \
+  -X POST http://localhost:3001/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 7,
+    "method": "getWorkflowStatus",
+    "params": {
+      "workflowId": "test-workflow-123"
+    }
+  }'
+```
+
 ### REST API Examples
 
 #### 1. Get all available methods
@@ -246,6 +278,26 @@ curl -u admin:admin \
     "depth": 1,
     "limit": 10
   }'
+```
+
+#### 4. Start a workflow
+```bash
+curl -u admin:admin \
+  -X POST http://localhost:3001/api/methods/startWorkflow \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "modelId": "/var/workflow/models/publish-page",
+    "payloadPath": "/content/mysite/en",
+    "title": "Publish Page"
+  }'
+```
+
+#### 5. Get workflow status
+```bash
+curl -u admin:admin \
+  -X POST http://localhost:3001/api/methods/getWorkflowStatus \
+  -H 'Content-Type: application/json' \
+  -d '{ "workflowId": "test-workflow-123" }'
 ```
 
 ### Method Categories and Examples
@@ -290,6 +342,10 @@ curl -u admin:admin \
 - `fetchSites` - Get all available sites
 - `fetchLanguageMasters` - Get language masters for sites
 - `fetchAvailableLocales` - Get available locales
+
+#### Workflow Operations
+- `startWorkflow` - Start workflows using a model and payload path
+- `getWorkflowStatus` - Retrieve workflow instance status by ID
 
 ### Interactive Dashboard
 Access the web dashboard at `http://localhost:3001/dashboard` for:

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -4,8 +4,8 @@ This guide provides instructions for deploying and configuring the AEM MCP Serve
 
 ## System Requirements
 
-- **Node.js**: v14.x or higher
-- **NPM**: v6.x or higher
+- **Node.js**: v18.x or higher
+- **NPM**: v9.x or higher
 - **Memory**: Minimum 2GB RAM
 - **Disk Space**: Minimum 500MB free space
 - **Network**: Access to AEM Author instance
@@ -150,7 +150,7 @@ The server provides a health endpoint at `/health` that returns the current stat
     "responseTime": 245
   },
   "mcp": {
-    "methodCount": 35,
+    "methodCount": 37,
     "lastMethodCall": "2025-07-21T12:30:00.000Z"
   },
   "system": {

--- a/docs/method-metadata.ts
+++ b/docs/method-metadata.ts
@@ -450,6 +450,49 @@ export const AEM_MCP_METHODS: MethodMetadata[] = [
     version: '1.0.0',
     implementationStatus: 'complete'
   },
+  // Workflow Operations
+  {
+    name: 'startWorkflow',
+    description: 'Start an AEM workflow using a model and payload',
+    category: 'workflow',
+    parameters: [
+      { name: 'modelId', type: 'string', required: true, description: 'Workflow model ID', examples: ['/var/workflow/models/publish-page'] },
+      { name: 'payloadPath', type: 'string', required: true, description: 'AEM path that the workflow will act on', examples: ['/content/mysite/en'] },
+      { name: 'title', type: 'string', required: false, description: 'Optional workflow title', examples: ['Publish Page'] }
+    ],
+    examples: [
+      {
+        title: 'Start workflow',
+        description: 'Start a workflow for a page',
+        request: { modelId: '/var/workflow/models/publish-page', payloadPath: '/content/mysite/en', title: 'Publish Page' },
+        expectedResponse: { success: true, workflowId: 'test-workflow-123', modelId: '/var/workflow/models/publish-page' }
+      }
+    ],
+    returnType: 'object',
+    errorCodes: ['WORKFLOW_START_FAILED', 'INVALID_PARAMETERS'],
+    version: '1.0.0',
+    implementationStatus: 'complete'
+  },
+  {
+    name: 'getWorkflowStatus',
+    description: 'Get workflow status by ID',
+    category: 'workflow',
+    parameters: [
+      { name: 'workflowId', type: 'string', required: true, description: 'Workflow instance ID', examples: ['test-workflow-123'] }
+    ],
+    examples: [
+      {
+        title: 'Get workflow status',
+        description: 'Retrieve current status of a workflow instance',
+        request: { workflowId: 'test-workflow-123' },
+        expectedResponse: { success: true, workflowId: 'test-workflow-123', state: 'RUNNING' }
+      }
+    ],
+    returnType: 'object',
+    errorCodes: ['WORKFLOW_NOT_FOUND', 'INVALID_PARAMETERS'],
+    version: '1.0.0',
+    implementationStatus: 'complete'
+  },
   // Utility Operations
   {
     name: 'listMethods',


### PR DESCRIPTION
## Summary
- document new `startWorkflow` and `getWorkflowStatus` APIs with JSON-RPC and REST examples
- add workflow section to method metadata and categories
- refresh deployment guide for Node.js 18+ and updated method counts

## Testing
- `npm test` *(fails: Cannot find module '/workspace/aem-mcp-server/dist/tests/run-tests.js')*


------
https://chatgpt.com/codex/tasks/task_e_68c76fe84998832e92ca2bbc7e2c299e